### PR TITLE
fix b64-handling of data in Python 3

### DIFF
--- a/IPython/nbconvert/transformers/extractfigure.py
+++ b/IPython/nbconvert/transformers/extractfigure.py
@@ -13,7 +13,9 @@ notebook file.  The extracted figures are returned in the 'resources' dictionary
 # Imports
 #-----------------------------------------------------------------------------
 
+import base64
 import sys
+
 from IPython.utils.traitlets import Unicode
 from .base import Transformer
 from IPython.utils import py3compat
@@ -65,15 +67,10 @@ class ExtractFigureTransformer(Transformer):
 
                     #Binary files are base64-encoded, SVG is already XML
                     if out_type in ('png', 'jpg', 'jpeg', 'pdf'):
-                        
-                        #Python3 base64 is in a separate library...
-                        if py3compat.PY3:
-                            
-                            #Base 64 decode the bytes
-                            import base64
-                            data = base64.b64decode(data)
-                        else:
-                            data = data.decode('base64')
+                        # data is b64-encoded as text (str, unicode)
+                        # decodestring only accepts bytes
+                        data = py3compat.cast_bytes(data)
+                        data = base64.decodestring(data)
                     elif sys.platform == 'win32':
                         data = data.replace('\n', '\r\n').encode("UTF-8")
                     else:


### PR DESCRIPTION
data comes in as b64 unicode, must be converted to b64 bytes then decoded to the original bytes.
